### PR TITLE
Build fix: avoid unary_function, removed in c++17

### DIFF
--- a/tracing/patch_subdivider.h
+++ b/tracing/patch_subdivider.h
@@ -38,8 +38,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define EPS 0.000001
 
 template<class MeshType>
-class SelMidPointFunctor : public std::unary_function<vcg::face::Pos<typename MeshType::FaceType> ,
-        typename MeshType::CoordType>
+class SelMidPointFunctor
 {
     typedef MeshType TriMeshType;
     typedef typename TriMeshType::CoordType    CoordType;

--- a/tracing/tracer_interface.h
+++ b/tracing/tracer_interface.h
@@ -43,7 +43,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // Basic subdivision class
 template<class MESH_TYPE>
-struct SplitLevTrace : public   std::unary_function<vcg::face::Pos<typename MESH_TYPE::FaceType> ,  typename MESH_TYPE::CoordType >
+struct SplitLevTrace
 {
     typedef typename MESH_TYPE::VertexType VertexType;
     typedef typename MESH_TYPE::FaceType FaceType;

--- a/tracing/vert_field_graph.h
+++ b/tracing/vert_field_graph.h
@@ -1350,7 +1350,7 @@ public:
             std::vector<NeighInfo> SwapNeigh;
             for (size_t j=0;j<Nodes[i].Neigh.size();j++)
             {
-                if (IndexNodes.count(Nodes[i].Neigh[j].Node>0))continue;
+                if (IndexNodes.count(Nodes[i].Neigh[j].Node)>0)continue;
                 SwapNeigh.push_back(Nodes[i].Neigh[j]);
             }
             if (SwapNeigh.size()==Nodes[i].Neigh.size())continue;

--- a/tracing/vert_field_graph.h
+++ b/tracing/vert_field_graph.h
@@ -1433,7 +1433,7 @@ void SplitAdjacentSingularities(MeshType &mesh)
     typedef std::pair<CoordType,CoordType> CoordPair;
 
     // Basic subdivision class
-    struct SplitLev : public   std::unary_function<vcg::face::Pos<FaceType> ,CoordType >
+    struct SplitLev
     {
         std::map<CoordPair,CoordType> *SplitOps;
 


### PR DESCRIPTION
This change was required to build with MSVC